### PR TITLE
Fix issue #8

### DIFF
--- a/harmony/harmony-server.js
+++ b/harmony/harmony-server.js
@@ -1,5 +1,6 @@
 var HarmonyHubDiscover = require('harmonyhubjs-discover')
 var harmonyClient = require('harmonyhubjs-client')
+var events = require('events')
 
 module.exports = function (RED) {
   function HarmonyServerNode (n) {
@@ -7,6 +8,7 @@ module.exports = function (RED) {
     var node = this
 
     node.ip = n.ip
+    node.harmonyEventEmitter = new events.EventEmitter()
     createClient(node)
 
     this.on('close', function () {
@@ -29,6 +31,9 @@ module.exports = function (RED) {
     }
     harmonyClient(ip).then(function (harmony) {
       node.harmony = harmony
+      harmony.on('stateDigest', function(digest) {
+        node.harmonyEventEmitter.emit('stateDigest', digest)
+      })
       !(function keepAlive () {
         harmony.request('getCurrentActivity').timeout(50000).then(function (response) {
           setTimeout(keepAlive, 50000)

--- a/harmony/harmony.js
+++ b/harmony/harmony.js
@@ -89,8 +89,8 @@ module.exports = function (RED) {
 
     setTimeout(function () {
       try {
-        node.server.harmony.on('stateDigest', function (digest) {
-          // console.log(JSON.stringify(digest));
+        node.server.harmonyEventEmitter.on('stateDigest', function (digest) {
+		  // console.log(JSON.stringify(digest));
           try {
             node.send({
               payload: {


### PR DESCRIPTION
If I didn't overlook anything else, then issue #8 occurs after the following things happen:

- ```HarmonyObserve (n)``` in harmony.js registers for events on the ```node.server.harmony``` object
- Eventually a timeout occurs in harmony-server.js, which causes the exception handler to call ```createClient(node)```, which replaces ```node.server.harmony``` with a new ```harmony``` object.
- The old ```harmony``` object, which carries the ```HarmonyObserver``` event registration, stops working.
- No listener is ever registered on the new ```node.server.harmony``` object, hence the observer node never notices an activity change.

The merge request introduces an ```EventEmitter``` in the server that persists even when ```node.server.harmony``` objects change. Observer nodes register for events with that ```EventEmitter```.

Feel free to edit whatever you like or to pursue an entirely different solution. I'm not too familiar with node js.