### PR TITLE
strip command structure on server

### DIFF
--- a/harmony/harmony-server.js
+++ b/harmony/harmony-server.js
@@ -68,6 +68,12 @@ module.exports = function (RED) {
                   harmony.getActivities()
                         .then(function (acts) {
                           harmony.end()
+                          acts = acts.map(function(action) {
+                            return {
+                              id: action.id,
+                              label: action.label
+                            }
+                          })
                           res.status(200).send(JSON.stringify(acts))
                         }).fail(function (err) {
                           harmony.end()


### PR DESCRIPTION
strip command structure on the server to needed properties on client side (id and label) to reduce client side parsing effort